### PR TITLE
画像アップロード時のバリデーションチェックを追加

### DIFF
--- a/board.php
+++ b/board.php
@@ -27,15 +27,58 @@ require_once('dao/product_comment.php');
 <?php
 $product_comment = '';
 $product_comment_image = '';
+//エラーメッセージの初期化
+$errors = array();
 
 if(!empty($_POST)){
-  var_dump($_POST);
-  if(!empty($_POST['product_comment'])){
-    $product_comment = $_POST['product_comment'];
-  }
+
+  //コメントのみの投稿可
+  //画像のみの投稿可
+  //どちらもない場合はエラー
+
+    //POSTされたデータを変数に入れる
+	  $product_comment = isset($_POST['product_comment']) ? $_POST['product_comment'] : NULL;
+    //$product_comment = $_POST['product_comment'];
+
+    //前後にある半角全角スペースを削除
+    $product_comment = spaceTrim($product_comment);
+
+    //入力判定
+    if ($product_comment == ''){
+      //画像アップロードされていなかった場合
+      if(empty($_FILES['image_file']['name'])){
+        $errors['product_comment_none'] = "コメントが入力されていません。";
+      }
+    }elseif(mb_strlen($product_comment)>1000){
+      $errors['product_comment_length'] = "コメントは1000文字以内で入力して下さい。";
+    }
+  
+  //アップロードファイルの判定
   if(!empty($_FILES['image_file']['name'])){
     try {
       if (is_uploaded_file ( $_FILES ['image_file'] ['tmp_name'] )) {
+        //ファイルのMIMEタイプをチェック
+        if (!isset($_FILES['image_file']['error']) || !is_int($_FILES['image_file']['error'])) {
+            exit("パラメータが不正です");
+        }
+        // $_FILES['image_file']['error'] の値を確認
+        switch ($_FILES['image_file']['error']) {
+          case UPLOAD_ERR_OK: // OK
+              break;
+          case UPLOAD_ERR_NO_FILE:   // ファイル未選択
+              exit("ファイルが選択されていません");
+          case UPLOAD_ERR_INI_SIZE:  // php.ini定義の最大サイズ超過
+          case UPLOAD_ERR_FORM_SIZE: // フォーム定義の最大サイズ超過 (フォームで設定した場合のみ)
+              exit("画像のファイルサイズは2MBまでです");
+          default:
+              exit("その他のエラーが発生しました");
+        }
+
+      //ここで定義するサイズ上限のオーバーチェック
+      if ($_FILES['image_file']['size'] > 2097152 ) {
+          exit("画像のファイルサイズは2MBまでです");
+      }
+
       $product_comment_image = uniqid();
       switch (exif_imagetype ( $_FILES['image_file']['tmp_name'])) {
         case IMAGETYPE_JPEG :
@@ -48,26 +91,46 @@ if(!empty($_POST)){
             $product_comment_image .= '.png';
             break;
         default :
-            header ( 'Location: board.php' );
-            exit ();
+            exit("アップロード可能なファイルは[jpeg] [png] [gif]のみです。");
       }
-      // ファイルを一時フォルダから指定したディレクトリに移動
-      move_uploaded_file($_FILES['image_file']['tmp_name'], 'upload/'. $product_comment_image);
+
+      //ファイルを一時フォルダから指定したディレクトリに移動
+      if(!move_uploaded_file($_FILES['image_file']['tmp_name'], 'upload/'. $product_comment_image)){
+          exit("ファイル保存時にエラーが発生しました");
       }
-    } catch (PDOException $e) {
+      }
+    } catch (RuntimeException $e) {
       exit("アップロードに失敗しました");
-    }
+  }
   }
 
+//エラーが無ければデータベースに登録
+if(count($errors) === 0){
   $pdo = db_connect();
-  try{ //コメント投稿があればデータベースへ登録する
+  try{ //コメントをデータベースへ登録する
     insert_product_comment($product_comment,$product_comment_image);
   } catch (PDOException $e) {
     exit("登録に失敗しました");
   }
   //リロードによる二重サブミット防止策
   header('Location:http://192.168.33.10/board/board.php');
-} ?>
+
+} elseif(count($errors) > 0){ ?>
+
+	<li class="step3 active error">
+	<p>エラー<br>下記メッセージをご確認ください。</p>
+	<p class="number"><span class="fa-stack fa-lg">
+	<i class="fa fa-circle fa-stack-2x"></i>
+	<i class="fa fa-inverse fa-stack-1x">!</i>
+	</span></p>
+	</li>
+    <?php foreach($errors as $error){ ?>
+      <div class='alert-notify-box'><p class='alert-notify-box-text'><?=he($error)?></p></div>
+    <?php
+    }
+}
+}
+?>
 
 <div class="container-fluid">
 
@@ -82,7 +145,8 @@ if(!empty($_POST)){
   <div class="form-group">
     <div class="input-group">
       <div class="custom-file">
-          <input type="file" name="image_file" class="custom-file-input" id="customFile">
+          <!-- <input type="hidden" name="MAX_FILE_SIZE" value="10"> -->
+          <input type="file" name="image_file" accept="image/jpeg, image/png, image/gif" class="custom-file-input" id="customFile">
           <label class="custom-file-label" for="customFile" data-browse="参照">ファイル選択...</label>
       </div>
       <div class="input-group-append">
@@ -104,7 +168,9 @@ if(!empty($_POST)){
     //コメントループの開始
     foreach ($product_comments as $product_rowcomment) { ?>
       <div class="card bg-light">
+      <?php if ($product_rowcomment['image']){ ?>
         <img class="card-img-top" src="./upload/<?= he($product_rowcomment['image']);?>" alt="コメントの画像">
+      <?php } ?>
         <div class="card-body">
           <p class="card-text"><?= he($product_rowcomment['comment']);?></p>
           <p class="card-text"><small class="text-muted"><?= he($product_rowcomment['create_date']);?></small></p>

--- a/board.php
+++ b/board.php
@@ -38,18 +38,17 @@ if(!empty($_POST)){
 
     //POSTされたデータを変数に入れる
 	  $product_comment = isset($_POST['product_comment']) ? $_POST['product_comment'] : NULL;
-    //$product_comment = $_POST['product_comment'];
 
     //前後にある半角全角スペースを削除
     $product_comment = spaceTrim($product_comment);
 
     //入力判定
-    if ($product_comment == ''){
+    if (empty($product_comment)) {
       //画像アップロードされていなかった場合
       if(empty($_FILES['image_file']['name'])){
         $errors['product_comment_none'] = "コメントが入力されていません。";
       }
-    }elseif(mb_strlen($product_comment)>1000){
+    }elseif(mb_strlen($product_comment) > 1000){
       $errors['product_comment_length'] = "コメントは1000文字以内で入力して下さい。";
     }
   
@@ -67,11 +66,14 @@ if(!empty($_POST)){
               break;
           case UPLOAD_ERR_NO_FILE:   // ファイル未選択
               exit("ファイルが選択されていません");
+              break;
           case UPLOAD_ERR_INI_SIZE:  // php.ini定義の最大サイズ超過
           case UPLOAD_ERR_FORM_SIZE: // フォーム定義の最大サイズ超過 (フォームで設定した場合のみ)
               exit("画像のファイルサイズは2MBまでです");
+              break;
           default:
               exit("その他のエラーが発生しました");
+              break;
         }
 
       //ここで定義するサイズ上限のオーバーチェック
@@ -92,6 +94,7 @@ if(!empty($_POST)){
             break;
         default :
             exit("アップロード可能なファイルは[jpeg] [png] [gif]のみです。");
+            break;
       }
 
       //ファイルを一時フォルダから指定したディレクトリに移動

--- a/board.php
+++ b/board.php
@@ -37,7 +37,7 @@ if(!empty($_POST)){
   //どちらもない場合はエラー
 
     //POSTされたデータを変数に入れる
-	  $product_comment = isset($_POST['product_comment']) ? $_POST['product_comment'] : NULL;
+    $product_comment = isset($_POST['product_comment']) ? $_POST['product_comment'] : NULL;
 
     //前後にある半角全角スペースを削除
     $product_comment = spaceTrim($product_comment);

--- a/functions.php
+++ b/functions.php
@@ -3,3 +3,13 @@
   function he($str){
       return htmlentities($str, ENT_QUOTES, "UTF-8");
   }
+
+  //前後にある半角全角スペースを削除する関数
+  function spaceTrim ($str) {
+    // 行頭
+    $str = preg_replace('/^[ 　]+/u', '', $str);
+    // 末尾
+    $str = preg_replace('/[ 　]+$/u', '', $str);
+    return $str;
+  }
+


### PR DESCRIPTION
## 目的
- 公開しても問題のない画像アップロード掲示板の作成

## 内容
- 投稿時のバリデーションチェックを追加
- 画像アップロード時
  - 容量制限を追加
  - 拡張子制限を追加
  - 画像のファイル名をユニークな値へ変更保存するよう修正

## 仕様
 - コメント、画像、の両方がない場合は投稿不可
 - 投稿画像は2MBまで
 - コメントは1000文字まで

## 不安点
 - ソースは綺麗に簡潔に書けているでしょうか？
 - 仕様通りのものが出来上がっているでしょうか？
 - ブラウザ側のフォームでは画像の容量制限をかけていませんが、この実装でも問題ないでしょうか？

以上、よろしくお願い致します
